### PR TITLE
Add laravel shift for laravel 9 for felixkiss/uniquewith-validator package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,12 @@
             "homepage": "https://github.com/konnekto/laravel-subscriptions/contributors"
         }
     ],
+    "repositories": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/laravel-shift/uniquewith-validator.git"
+        }
+    ],
     "require": {
         "php": "^8.0.0",
         "illuminate/console": "^9.0.0 || ^10.0.0",


### PR DESCRIPTION
`konnekto/laravel-subscriptions` using old version of [rinvex/laravel-support](https://packagist.org/packages/rinvex/laravel-support), which again using a package `felixkiss/uniquewith-validator` which do not support Laravel 9. So according to their [docs](https://github.com/rinvex/laravel-support#note-for-laravel-v9), they provided this hack for now to add laravel 9 support.

There is already a open [PR](https://github.com/rinvex/laravel-support/pull/66) to add support of laravel 9. After that open PR is merged we can remove this `uniquewith-validator` respository  